### PR TITLE
Fix quaternion readings

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -195,13 +195,23 @@ where
         val
     }
 
+    fn try_read_i16_at_cursor(msg: &[u8], cursor: &mut usize) -> Option<i16> {
+        let remaining = msg.len() - *cursor;
+        if remaining >= 2 {
+            let val = (msg[*cursor] as i16) | ((msg[*cursor + 1] as i16) << 8);
+            *cursor += 2;
+            Some(val)
+        } else {
+            None
+        }
+    }
+
     /// Read data values from a single input report
     fn handle_one_input_report(
         outer_cursor: usize,
         msg: &[u8],
     ) -> (usize, u8, i16, i16, i16, i16, i16) {
         let mut cursor = outer_cursor;
-        let remaining = msg.len() - cursor;
 
         let feature_report_id = Self::read_u8_at_cursor(msg, &mut cursor);
         let _rep_seq_num = Self::read_u8_at_cursor(msg, &mut cursor);
@@ -211,16 +221,8 @@ where
         let data1: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
         let data2: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
         let data3: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
-        let data4: i16 = if remaining > 14 {
-            Self::read_i16_at_cursor(msg, &mut cursor)
-        } else {
-            0
-        };
-        let data5: i16 = if remaining > 16 {
-            Self::read_i16_at_cursor(msg, &mut cursor)
-        } else {
-            0
-        };
+        let data4: i16 = Self::try_read_i16_at_cursor(msg, &mut cursor).unwrap_or(0);
+        let data5: i16 = Self::try_read_i16_at_cursor(msg, &mut cursor).unwrap_or(0);
 
         (cursor, feature_report_id, data1, data2, data3, data4, data5)
     }


### PR DESCRIPTION
Hello,

First of all, thank you for all your hard work with this driver. I really appreciate it and grateful that I could find this.

I'm using BNO085 in my project and noticed, that I'm always getting zero in the last term of a quaternion. By looking at [SH-2 Reference Manual](https://cdn.sparkfun.com/assets/4/d/9/3/8/SH-2-Reference-Manual-v1.2.pdf) it seems that it's a `real` part of a unit quaternion that seems to be missing in the reading. Since this value is required to obtain a full quaternion, I tried to read it from the report anyway by just removing the `if` condition [here](https://github.com/tstellanova/bno080/blob/ef69c89eebf9f767620160a85f44b06bcd2641a2/src/wrapper.rs#L214). After that, I started getting non-zero value and this quaternion started to make sense.

Looking at the report structure I realized that it's indeed 14 bytes that need to be read and more than that is present there, but the condition is always false due to non-inclusive bound (probably a usual off-by-one/fencepost bug).

This PR adds an optional reading of the report fields that may or may not be present in the input report, although I was only interested in `0x05 Rotation Vector` report and shorter input reports might fail to be read.