### PR TITLE
initial implementation of async i2c driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea
+.vscode/settings.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 [dependencies]
 embedded-hal = { version = "1" }
 panic-rtt-core = { version = "0.2.1", optional = true }
+embedded-hal-async = { version = "1", optional = true }
 
 [features]
 default = []
 rttdebug = ["panic-rtt-core"]
+async = ["embedded-hal-async"]

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -1,4 +1,5 @@
-use super::{SensorCommon, SensorInterface, PACKET_HEADER_LENGTH};
+use super::i2c_common::I2cCommon;
+use super::{SensorInterface, PACKET_HEADER_LENGTH};
 use crate::Error;
 
 use embedded_hal::delay::DelayNs;
@@ -6,26 +7,12 @@ use embedded_hal::delay::DelayNs;
 #[cfg(feature = "rttdebug")]
 use panic_rtt_core::rprintln;
 
-/// the i2c address normally used by BNO080
-pub const DEFAULT_ADDRESS: u8 = 0x4A;
-/// alternate i2c address for BNO080
-pub const ALTERNATE_ADDRESS: u8 = 0x4B;
-
-/// Length of our receive buffer:
-/// Note that this likely needs to be < 256 to accommodate underlying HAL
-const SEG_RECV_BUF_LEN: usize = 240;
-const MAX_SEGMENT_READ: usize = SEG_RECV_BUF_LEN;
+pub use super::i2c_common::{ALTERNATE_ADDRESS, DEFAULT_ADDRESS};
 
 pub struct I2cInterface<I2C> {
     /// i2c port
     i2c_port: I2C,
-    /// address for i2c communications with the sensor hub
-    address: u8,
-    /// buffer for receiving segments of packets from the sensor hub
-    seg_recv_buf: [u8; SEG_RECV_BUF_LEN],
-
-    /// number of packets received
-    received_packet_count: usize,
+    common: I2cCommon,
 }
 
 impl<I2C, CommE> I2cInterface<I2C>
@@ -43,9 +30,7 @@ where
     pub fn new(i2c: I2C, addr: u8) -> Self {
         Self {
             i2c_port: i2c,
-            address: addr,
-            seg_recv_buf: [0; SEG_RECV_BUF_LEN],
-            received_packet_count: 0,
+            common: I2cCommon::new(addr),
         }
     }
 
@@ -54,9 +39,13 @@ where
     }
 
     fn read_packet_header(&mut self) -> Result<(), Error<CommE, ()>> {
-        self.zero_recv_packet_header();
+        self.common.zero_recv_packet_header();
+        let address = self.common.address();
         self.i2c_port
-            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .read(
+                address,
+                &mut self.common.seg_recv_buf_mut()[..PACKET_HEADER_LENGTH],
+            )
             .map_err(Error::Comm)?;
 
         Ok(())
@@ -68,95 +57,49 @@ where
         total_packet_len: usize,
         packet_recv_buf: &mut [u8],
     ) -> Result<usize, Error<CommE, ()>> {
-        let mut remaining_body_len: usize =
-            total_packet_len - PACKET_HEADER_LENGTH;
-        let mut already_read_len: usize = 0;
-
-        // zero packet header receive buffer
-        for byte in &mut packet_recv_buf[..PACKET_HEADER_LENGTH] {
-            *byte = 0;
-        }
+        let mut sized_read =
+            I2cCommon::sized_read(total_packet_len, packet_recv_buf);
 
         // #[cfg(feature = "rttdebug")]
         // rprintln!("r.t {}", total_packet_len);
 
-        if total_packet_len < MAX_SEGMENT_READ {
-            //read directly into the provided receive buffer
-            if total_packet_len > 0 {
-                self.i2c_port
-                    .read(
-                        self.address,
-                        &mut packet_recv_buf[..total_packet_len],
-                    )
-                    .map_err(Error::Comm)?;
-                already_read_len = total_packet_len;
-            }
-        } else {
-            while remaining_body_len > 0 {
-                let whole_segment_length =
-                    remaining_body_len + PACKET_HEADER_LENGTH;
-                let segment_read_len =
-                    if whole_segment_length > MAX_SEGMENT_READ {
-                        MAX_SEGMENT_READ
-                    } else {
-                        whole_segment_length
-                    };
-                // #[cfg(feature = "rttdebug")]
-                // rprintln!("r.s {:x} {}", self.address, segment_read_len);
-
-                self.zero_recv_packet_header();
-                self.i2c_port
-                    .read(
-                        self.address,
-                        &mut self.seg_recv_buf[..segment_read_len],
-                    )
-                    .map_err(Error::Comm)?;
-
-                let promised_packet_len = SensorCommon::parse_packet_header(
-                    &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-                );
-                if promised_packet_len <= PACKET_HEADER_LENGTH {
-                    #[cfg(feature = "rttdebug")]
-                    rprintln!("WTFFF {}", promised_packet_len);
-                    return Ok(0);
-                }
-
-                //if we've never read any segments, transcribe the first packet header;
-                //otherwise, just transcribe the segment body (no header)
-                let transcribe_start_idx = if already_read_len > 0 {
-                    PACKET_HEADER_LENGTH
-                } else {
-                    0
-                };
-                let transcribe_len = if already_read_len > 0 {
-                    segment_read_len - PACKET_HEADER_LENGTH
-                } else {
-                    segment_read_len
-                };
-                packet_recv_buf
-                    [already_read_len..already_read_len + transcribe_len]
-                    .copy_from_slice(
-                        &self.seg_recv_buf[transcribe_start_idx
-                            ..transcribe_start_idx + transcribe_len],
-                    );
-                already_read_len += transcribe_len;
-
-                let body_read_len = segment_read_len - PACKET_HEADER_LENGTH;
-                remaining_body_len -= body_read_len;
-            }
+        if let Some(read_len) = sized_read.direct_read_len() {
+            let address = self.common.address();
+            self.i2c_port
+                .read(address, &mut packet_recv_buf[..read_len])
+                .map_err(Error::Comm)?;
+            return Ok(sized_read.finish_direct_read(read_len));
         }
 
-        Ok(already_read_len)
-    }
+        while sized_read.has_remaining_segments() {
+            let segment_read_len = sized_read.next_segment_read_len();
+            // #[cfg(feature = "rttdebug")]
+            // rprintln!("r.s {:x} {}", self.common.address(), segment_read_len);
 
-    fn zero_recv_packet_header(&mut self) {
-        Self::zero_buffer(&mut self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
-    }
+            self.common.zero_recv_packet_header();
+            let address = self.common.address();
+            self.i2c_port
+                .read(
+                    address,
+                    &mut self.common.seg_recv_buf_mut()[..segment_read_len],
+                )
+                .map_err(Error::Comm)?;
 
-    fn zero_buffer(buf: &mut [u8]) {
-        for byte in buf {
-            *byte = 0;
+            let promised_packet_len = self.common.packet_len_from_header();
+            if promised_packet_len <= PACKET_HEADER_LENGTH {
+                #[cfg(feature = "rttdebug")]
+                rprintln!("WTFFF {}", promised_packet_len);
+                return Ok(0);
+            }
+
+            sized_read.transcribe_segment(
+                segment_read_len,
+                self.common.seg_recv_buf(),
+                packet_recv_buf,
+            );
         }
+
+        Ok(sized_read.already_read_len())
     }
 }
 
@@ -182,10 +125,9 @@ where
 
     fn write_packet(&mut self, packet: &[u8]) -> Result<(), Self::SensorError> {
         #[cfg(feature = "rttdebug")]
-        rprintln!("w {:x} {}", self.address, packet.len());
-        self.i2c_port
-            .write(self.address, packet)
-            .map_err(Error::Comm)?;
+        rprintln!("w {:x} {}", self.common.address(), packet.len());
+        let address = self.common.address();
+        self.i2c_port.write(address, packet).map_err(Error::Comm)?;
         Ok(())
     }
 
@@ -223,13 +165,11 @@ where
         // rprintln!("rpkt");
 
         self.read_packet_header()?;
-        let packet_len = SensorCommon::parse_packet_header(
-            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-        );
+        let packet_len = self.common.packet_len_from_header();
 
         // if packet_len == 0 {
         //     #[cfg(feature = "rttdebug")]
-        //     rprintln!("eh {:x?}", &self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
+        //     rprintln!("eh {:x?}", &self.common.seg_recv_buf()[..PACKET_HEADER_LENGTH]);
         // }
 
         let received_len = if packet_len > PACKET_HEADER_LENGTH {
@@ -238,10 +178,7 @@ where
             packet_len
         };
 
-        if packet_len > 0 {
-            self.received_packet_count += 1;
-            //let _ = SensorCommon::parse_packet_header(&recv_buf[..packet_len]);
-        }
+        self.common.record_received_packet(packet_len);
 
         Ok(received_len)
     }
@@ -254,30 +191,30 @@ where
         // Cannot use write_read with bno080,
         // because it does not support repeated start with i2c.
 
+        let address = self.common.address();
         self.i2c_port
-            .write(self.address, send_buf)
+            .write(address, send_buf)
             .map_err(Error::Comm)?;
 
-        self.zero_recv_packet_header();
+        self.common.zero_recv_packet_header();
         //stall before attempted read?
-        Self::zero_buffer(recv_buf);
+        I2cCommon::zero_buffer(recv_buf);
 
         self.i2c_port
-            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .read(
+                address,
+                &mut self.common.seg_recv_buf_mut()[..PACKET_HEADER_LENGTH],
+            )
             .map_err(Error::Comm)?;
 
-        let packet_len = SensorCommon::parse_packet_header(
-            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-        );
+        let packet_len = self.common.packet_len_from_header();
 
         let received_len = if packet_len > PACKET_HEADER_LENGTH {
             self.read_sized_packet(packet_len, recv_buf)?
         } else {
             packet_len
         };
-        if packet_len > 0 {
-            self.received_packet_count += 1;
-        }
+        self.common.record_received_packet(packet_len);
 
         Ok(received_len)
     }

--- a/src/interface/i2c_async.rs
+++ b/src/interface/i2c_async.rs
@@ -1,4 +1,5 @@
-use super::{SensorCommon, SensorInterfaceAsync, PACKET_HEADER_LENGTH};
+use super::i2c_common::I2cCommon;
+use super::{SensorInterfaceAsync, PACKET_HEADER_LENGTH};
 use crate::Error;
 
 use embedded_hal_async::delay::DelayNs;
@@ -6,26 +7,12 @@ use embedded_hal_async::delay::DelayNs;
 #[cfg(feature = "rttdebug")]
 use panic_rtt_core::rprintln;
 
-/// the i2c address normally used by BNO080
-pub const DEFAULT_ADDRESS: u8 = 0x4A;
-/// alternate i2c address for BNO080
-pub const ALTERNATE_ADDRESS: u8 = 0x4B;
-
-/// Length of our receive buffer:
-/// Note that this likely needs to be < 256 to accommodate underlying HAL
-const SEG_RECV_BUF_LEN: usize = 240;
-const MAX_SEGMENT_READ: usize = SEG_RECV_BUF_LEN;
+pub use super::i2c_common::{ALTERNATE_ADDRESS, DEFAULT_ADDRESS};
 
 pub struct I2cInterfaceAsync<I2C> {
     /// i2c port
     i2c_port: I2C,
-    /// address for i2c communications with the sensor hub
-    address: u8,
-    /// buffer for receiving segments of packets from the sensor hub
-    seg_recv_buf: [u8; SEG_RECV_BUF_LEN],
-
-    /// number of packets received
-    received_packet_count: usize,
+    common: I2cCommon,
 }
 
 impl<I2C, CommE> I2cInterfaceAsync<I2C>
@@ -43,9 +30,7 @@ where
     pub fn new(i2c: I2C, addr: u8) -> Self {
         Self {
             i2c_port: i2c,
-            address: addr,
-            seg_recv_buf: [0; SEG_RECV_BUF_LEN],
-            received_packet_count: 0,
+            common: I2cCommon::new(addr),
         }
     }
 
@@ -54,9 +39,13 @@ where
     }
 
     async fn read_packet_header(&mut self) -> Result<(), Error<CommE, ()>> {
-        self.zero_recv_packet_header();
+        self.common.zero_recv_packet_header();
+        let address = self.common.address();
         self.i2c_port
-            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .read(
+                address,
+                &mut self.common.seg_recv_buf_mut()[..PACKET_HEADER_LENGTH],
+            )
             .await
             .map_err(Error::Comm)?;
 
@@ -69,97 +58,51 @@ where
         total_packet_len: usize,
         packet_recv_buf: &mut [u8],
     ) -> Result<usize, Error<CommE, ()>> {
-        let mut remaining_body_len: usize =
-            total_packet_len - PACKET_HEADER_LENGTH;
-        let mut already_read_len: usize = 0;
-
-        // zero packet header receive buffer
-        for byte in &mut packet_recv_buf[..PACKET_HEADER_LENGTH] {
-            *byte = 0;
-        }
+        let mut sized_read =
+            I2cCommon::sized_read(total_packet_len, packet_recv_buf);
 
         // #[cfg(feature = "rttdebug")]
         // rprintln!("r.t {}", total_packet_len);
 
-        if total_packet_len < MAX_SEGMENT_READ {
-            //read directly into the provided receive buffer
-            if total_packet_len > 0 {
-                self.i2c_port
-                    .read(
-                        self.address,
-                        &mut packet_recv_buf[..total_packet_len],
-                    )
-                    .await
-                    .map_err(Error::Comm)?;
-                already_read_len = total_packet_len;
-            }
-        } else {
-            while remaining_body_len > 0 {
-                let whole_segment_length =
-                    remaining_body_len + PACKET_HEADER_LENGTH;
-                let segment_read_len =
-                    if whole_segment_length > MAX_SEGMENT_READ {
-                        MAX_SEGMENT_READ
-                    } else {
-                        whole_segment_length
-                    };
-                // #[cfg(feature = "rttdebug")]
-                // rprintln!("r.s {:x} {}", self.address, segment_read_len);
-
-                self.zero_recv_packet_header();
-                self.i2c_port
-                    .read(
-                        self.address,
-                        &mut self.seg_recv_buf[..segment_read_len],
-                    )
-                    .await
-                    .map_err(Error::Comm)?;
-
-                let promised_packet_len = SensorCommon::parse_packet_header(
-                    &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-                );
-                if promised_packet_len <= PACKET_HEADER_LENGTH {
-                    #[cfg(feature = "rttdebug")]
-                    rprintln!("WTFFF {}", promised_packet_len);
-                    return Ok(0);
-                }
-
-                //if we've never read any segments, transcribe the first packet header;
-                //otherwise, just transcribe the segment body (no header)
-                let transcribe_start_idx = if already_read_len > 0 {
-                    PACKET_HEADER_LENGTH
-                } else {
-                    0
-                };
-                let transcribe_len = if already_read_len > 0 {
-                    segment_read_len - PACKET_HEADER_LENGTH
-                } else {
-                    segment_read_len
-                };
-                packet_recv_buf
-                    [already_read_len..already_read_len + transcribe_len]
-                    .copy_from_slice(
-                        &self.seg_recv_buf[transcribe_start_idx
-                            ..transcribe_start_idx + transcribe_len],
-                    );
-                already_read_len += transcribe_len;
-
-                let body_read_len = segment_read_len - PACKET_HEADER_LENGTH;
-                remaining_body_len -= body_read_len;
-            }
+        if let Some(read_len) = sized_read.direct_read_len() {
+            let address = self.common.address();
+            self.i2c_port
+                .read(address, &mut packet_recv_buf[..read_len])
+                .await
+                .map_err(Error::Comm)?;
+            return Ok(sized_read.finish_direct_read(read_len));
         }
 
-        Ok(already_read_len)
-    }
+        while sized_read.has_remaining_segments() {
+            let segment_read_len = sized_read.next_segment_read_len();
+            // #[cfg(feature = "rttdebug")]
+            // rprintln!("r.s {:x} {}", self.common.address(), segment_read_len);
 
-    fn zero_recv_packet_header(&mut self) {
-        Self::zero_buffer(&mut self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
-    }
+            self.common.zero_recv_packet_header();
+            let address = self.common.address();
+            self.i2c_port
+                .read(
+                    address,
+                    &mut self.common.seg_recv_buf_mut()[..segment_read_len],
+                )
+                .await
+                .map_err(Error::Comm)?;
 
-    fn zero_buffer(buf: &mut [u8]) {
-        for byte in buf {
-            *byte = 0;
+            let promised_packet_len = self.common.packet_len_from_header();
+            if promised_packet_len <= PACKET_HEADER_LENGTH {
+                #[cfg(feature = "rttdebug")]
+                rprintln!("WTFFF {}", promised_packet_len);
+                return Ok(0);
+            }
+
+            sized_read.transcribe_segment(
+                segment_read_len,
+                self.common.seg_recv_buf(),
+                packet_recv_buf,
+            );
         }
+
+        Ok(sized_read.already_read_len())
     }
 }
 
@@ -188,9 +131,10 @@ where
         packet: &[u8],
     ) -> Result<(), Self::SensorError> {
         #[cfg(feature = "rttdebug")]
-        rprintln!("w {:x} {}", self.address, packet.len());
+        rprintln!("w {:x} {}", self.common.address(), packet.len());
+        let address = self.common.address();
         self.i2c_port
-            .write(self.address, packet)
+            .write(address, packet)
             .await
             .map_err(Error::Comm)?;
         Ok(())
@@ -230,13 +174,11 @@ where
         // rprintln!("rpkt");
 
         self.read_packet_header().await?;
-        let packet_len = SensorCommon::parse_packet_header(
-            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-        );
+        let packet_len = self.common.packet_len_from_header();
 
         // if packet_len == 0 {
         //     #[cfg(feature = "rttdebug")]
-        //     rprintln!("eh {:x?}", &self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
+        //     rprintln!("eh {:x?}", &self.common.seg_recv_buf()[..PACKET_HEADER_LENGTH]);
         // }
 
         let received_len = if packet_len > PACKET_HEADER_LENGTH {
@@ -245,10 +187,7 @@ where
             packet_len
         };
 
-        if packet_len > 0 {
-            self.received_packet_count += 1;
-            //let _ = SensorCommon::parse_packet_header(&recv_buf[..packet_len]);
-        }
+        self.common.record_received_packet(packet_len);
 
         Ok(received_len)
     }
@@ -261,32 +200,32 @@ where
         // Cannot use write_read with bno080,
         // because it does not support repeated start with i2c.
 
+        let address = self.common.address();
         self.i2c_port
-            .write(self.address, send_buf)
+            .write(address, send_buf)
             .await
             .map_err(Error::Comm)?;
 
-        self.zero_recv_packet_header();
+        self.common.zero_recv_packet_header();
         //stall before attempted read?
-        Self::zero_buffer(recv_buf);
+        I2cCommon::zero_buffer(recv_buf);
 
         self.i2c_port
-            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .read(
+                address,
+                &mut self.common.seg_recv_buf_mut()[..PACKET_HEADER_LENGTH],
+            )
             .await
             .map_err(Error::Comm)?;
 
-        let packet_len = SensorCommon::parse_packet_header(
-            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
-        );
+        let packet_len = self.common.packet_len_from_header();
 
         let received_len = if packet_len > PACKET_HEADER_LENGTH {
             self.read_sized_packet(packet_len, recv_buf).await?
         } else {
             packet_len
         };
-        if packet_len > 0 {
-            self.received_packet_count += 1;
-        }
+        self.common.record_received_packet(packet_len);
 
         Ok(received_len)
     }

--- a/src/interface/i2c_async.rs
+++ b/src/interface/i2c_async.rs
@@ -1,0 +1,293 @@
+use super::{SensorCommon, SensorInterfaceAsync, PACKET_HEADER_LENGTH};
+use crate::Error;
+
+use embedded_hal_async::delay::DelayNs;
+
+#[cfg(feature = "rttdebug")]
+use panic_rtt_core::rprintln;
+
+/// the i2c address normally used by BNO080
+pub const DEFAULT_ADDRESS: u8 = 0x4A;
+/// alternate i2c address for BNO080
+pub const ALTERNATE_ADDRESS: u8 = 0x4B;
+
+/// Length of our receive buffer:
+/// Note that this likely needs to be < 256 to accommodate underlying HAL
+const SEG_RECV_BUF_LEN: usize = 240;
+const MAX_SEGMENT_READ: usize = SEG_RECV_BUF_LEN;
+
+pub struct I2cInterfaceAsync<I2C> {
+    /// i2c port
+    i2c_port: I2C,
+    /// address for i2c communications with the sensor hub
+    address: u8,
+    /// buffer for receiving segments of packets from the sensor hub
+    seg_recv_buf: [u8; SEG_RECV_BUF_LEN],
+
+    /// number of packets received
+    received_packet_count: usize,
+}
+
+impl<I2C, CommE> I2cInterfaceAsync<I2C>
+where
+    I2C: embedded_hal_async::i2c::I2c<Error = CommE>,
+{
+    pub fn default(i2c: I2C) -> Self {
+        Self::new(i2c, DEFAULT_ADDRESS)
+    }
+
+    pub fn alternate(i2c: I2C) -> Self {
+        Self::new(i2c, ALTERNATE_ADDRESS)
+    }
+
+    pub fn new(i2c: I2C, addr: u8) -> Self {
+        Self {
+            i2c_port: i2c,
+            address: addr,
+            seg_recv_buf: [0; SEG_RECV_BUF_LEN],
+            received_packet_count: 0,
+        }
+    }
+
+    pub fn free(self) -> I2C {
+        self.i2c_port
+    }
+
+    async fn read_packet_header(&mut self) -> Result<(), Error<CommE, ()>> {
+        self.zero_recv_packet_header();
+        self.i2c_port
+            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .await
+            .map_err(Error::Comm)?;
+
+        Ok(())
+    }
+
+    /// Read the remainder of the packet after the packet header, if any
+    async fn read_sized_packet(
+        &mut self,
+        total_packet_len: usize,
+        packet_recv_buf: &mut [u8],
+    ) -> Result<usize, Error<CommE, ()>> {
+        let mut remaining_body_len: usize =
+            total_packet_len - PACKET_HEADER_LENGTH;
+        let mut already_read_len: usize = 0;
+
+        // zero packet header receive buffer
+        for byte in &mut packet_recv_buf[..PACKET_HEADER_LENGTH] {
+            *byte = 0;
+        }
+
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("r.t {}", total_packet_len);
+
+        if total_packet_len < MAX_SEGMENT_READ {
+            //read directly into the provided receive buffer
+            if total_packet_len > 0 {
+                self.i2c_port
+                    .read(
+                        self.address,
+                        &mut packet_recv_buf[..total_packet_len],
+                    )
+                    .await
+                    .map_err(Error::Comm)?;
+                already_read_len = total_packet_len;
+            }
+        } else {
+            while remaining_body_len > 0 {
+                let whole_segment_length =
+                    remaining_body_len + PACKET_HEADER_LENGTH;
+                let segment_read_len =
+                    if whole_segment_length > MAX_SEGMENT_READ {
+                        MAX_SEGMENT_READ
+                    } else {
+                        whole_segment_length
+                    };
+                // #[cfg(feature = "rttdebug")]
+                // rprintln!("r.s {:x} {}", self.address, segment_read_len);
+
+                self.zero_recv_packet_header();
+                self.i2c_port
+                    .read(
+                        self.address,
+                        &mut self.seg_recv_buf[..segment_read_len],
+                    )
+                    .await
+                    .map_err(Error::Comm)?;
+
+                let promised_packet_len = SensorCommon::parse_packet_header(
+                    &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
+                );
+                if promised_packet_len <= PACKET_HEADER_LENGTH {
+                    #[cfg(feature = "rttdebug")]
+                    rprintln!("WTFFF {}", promised_packet_len);
+                    return Ok(0);
+                }
+
+                //if we've never read any segments, transcribe the first packet header;
+                //otherwise, just transcribe the segment body (no header)
+                let transcribe_start_idx = if already_read_len > 0 {
+                    PACKET_HEADER_LENGTH
+                } else {
+                    0
+                };
+                let transcribe_len = if already_read_len > 0 {
+                    segment_read_len - PACKET_HEADER_LENGTH
+                } else {
+                    segment_read_len
+                };
+                packet_recv_buf
+                    [already_read_len..already_read_len + transcribe_len]
+                    .copy_from_slice(
+                        &self.seg_recv_buf[transcribe_start_idx
+                            ..transcribe_start_idx + transcribe_len],
+                    );
+                already_read_len += transcribe_len;
+
+                let body_read_len = segment_read_len - PACKET_HEADER_LENGTH;
+                remaining_body_len -= body_read_len;
+            }
+        }
+
+        Ok(already_read_len)
+    }
+
+    fn zero_recv_packet_header(&mut self) {
+        Self::zero_buffer(&mut self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
+    }
+
+    fn zero_buffer(buf: &mut [u8]) {
+        for byte in buf {
+            *byte = 0;
+        }
+    }
+}
+
+impl<I2C, CommE> SensorInterfaceAsync for I2cInterfaceAsync<I2C>
+where
+    I2C: embedded_hal_async::i2c::I2c<Error = CommE>,
+{
+    type SensorError = Error<CommE, ()>;
+
+    fn requires_soft_reset(&self) -> bool {
+        true
+    }
+
+    async fn setup(
+        &mut self,
+        delay_source: &mut impl DelayNs,
+    ) -> Result<(), Self::SensorError> {
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("i2c setup");
+        delay_source.delay_ms(5).await;
+        Ok(())
+    }
+
+    async fn write_packet(
+        &mut self,
+        packet: &[u8],
+    ) -> Result<(), Self::SensorError> {
+        #[cfg(feature = "rttdebug")]
+        rprintln!("w {:x} {}", self.address, packet.len());
+        self.i2c_port
+            .write(self.address, packet)
+            .await
+            .map_err(Error::Comm)?;
+        Ok(())
+    }
+
+    async fn read_with_timeout(
+        &mut self,
+        recv_buf: &mut [u8],
+        delay_source: &mut impl DelayNs,
+        max_ms: u8,
+    ) -> Result<usize, Self::SensorError> {
+        let mut total_delay: u8 = 0;
+        while total_delay < max_ms {
+            match self.read_packet(recv_buf).await {
+                Ok(read_size) => {
+                    if 0 == read_size {
+                        // no data available yet...wait a while longer
+                        delay_source.delay_ms(1).await;
+                        total_delay += 1;
+                    } else {
+                        return Ok(read_size);
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(0)
+    }
+
+    /// Read one packet into the receive buffer
+    async fn read_packet(
+        &mut self,
+        recv_buf: &mut [u8],
+    ) -> Result<usize, Self::SensorError> {
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("rpkt");
+
+        self.read_packet_header().await?;
+        let packet_len = SensorCommon::parse_packet_header(
+            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
+        );
+
+        // if packet_len == 0 {
+        //     #[cfg(feature = "rttdebug")]
+        //     rprintln!("eh {:x?}", &self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
+        // }
+
+        let received_len = if packet_len > PACKET_HEADER_LENGTH {
+            self.read_sized_packet(packet_len, recv_buf).await?
+        } else {
+            packet_len
+        };
+
+        if packet_len > 0 {
+            self.received_packet_count += 1;
+            //let _ = SensorCommon::parse_packet_header(&recv_buf[..packet_len]);
+        }
+
+        Ok(received_len)
+    }
+
+    async fn send_and_receive_packet(
+        &mut self,
+        send_buf: &[u8],
+        recv_buf: &mut [u8],
+    ) -> Result<usize, Self::SensorError> {
+        // Cannot use write_read with bno080,
+        // because it does not support repeated start with i2c.
+
+        self.i2c_port
+            .write(self.address, send_buf)
+            .await
+            .map_err(Error::Comm)?;
+
+        self.zero_recv_packet_header();
+        //stall before attempted read?
+        Self::zero_buffer(recv_buf);
+
+        self.i2c_port
+            .read(self.address, &mut self.seg_recv_buf[..PACKET_HEADER_LENGTH])
+            .await
+            .map_err(Error::Comm)?;
+
+        let packet_len = SensorCommon::parse_packet_header(
+            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
+        );
+
+        let received_len = if packet_len > PACKET_HEADER_LENGTH {
+            self.read_sized_packet(packet_len, recv_buf).await?
+        } else {
+            packet_len
+        };
+        if packet_len > 0 {
+            self.received_packet_count += 1;
+        }
+
+        Ok(received_len)
+    }
+}

--- a/src/interface/i2c_common.rs
+++ b/src/interface/i2c_common.rs
@@ -1,0 +1,228 @@
+use super::{SensorCommon, PACKET_HEADER_LENGTH};
+
+/// the i2c address normally used by BNO080
+pub const DEFAULT_ADDRESS: u8 = 0x4A;
+/// alternate i2c address for BNO080
+pub const ALTERNATE_ADDRESS: u8 = 0x4B;
+
+/// Length of our receive buffer:
+/// Note that this likely needs to be < 256 to accommodate underlying HAL
+pub(crate) const SEG_RECV_BUF_LEN: usize = 240;
+pub(crate) const MAX_SEGMENT_READ: usize = SEG_RECV_BUF_LEN;
+
+pub(crate) struct I2cCommon {
+    /// address for i2c communications with the sensor hub
+    address: u8,
+    /// buffer for receiving segments of packets from the sensor hub
+    seg_recv_buf: [u8; SEG_RECV_BUF_LEN],
+    /// number of packets received
+    received_packet_count: usize,
+}
+
+impl I2cCommon {
+    pub(crate) fn new(address: u8) -> Self {
+        Self {
+            address,
+            seg_recv_buf: [0; SEG_RECV_BUF_LEN],
+            received_packet_count: 0,
+        }
+    }
+
+    pub(crate) fn address(&self) -> u8 {
+        self.address
+    }
+
+    pub(crate) fn seg_recv_buf(&self) -> &[u8; SEG_RECV_BUF_LEN] {
+        &self.seg_recv_buf
+    }
+
+    pub(crate) fn seg_recv_buf_mut(&mut self) -> &mut [u8; SEG_RECV_BUF_LEN] {
+        &mut self.seg_recv_buf
+    }
+
+    pub(crate) fn zero_recv_packet_header(&mut self) {
+        Self::zero_buffer(&mut self.seg_recv_buf[..PACKET_HEADER_LENGTH]);
+    }
+
+    pub(crate) fn zero_buffer(buf: &mut [u8]) {
+        for byte in buf {
+            *byte = 0;
+        }
+    }
+
+    pub(crate) fn packet_len_from_header(&self) -> usize {
+        SensorCommon::parse_packet_header(
+            &self.seg_recv_buf[..PACKET_HEADER_LENGTH],
+        )
+    }
+
+    pub(crate) fn record_received_packet(&mut self, packet_len: usize) {
+        if packet_len > 0 {
+            self.received_packet_count += 1;
+        }
+    }
+
+    pub(crate) fn sized_read(
+        total_packet_len: usize,
+        packet_recv_buf: &mut [u8],
+    ) -> SizedRead {
+        SizedRead::new(total_packet_len, packet_recv_buf)
+    }
+}
+
+pub(crate) struct SizedRead {
+    remaining_body_len: usize,
+    already_read_len: usize,
+    total_packet_len: usize,
+}
+
+impl SizedRead {
+    fn new(total_packet_len: usize, packet_recv_buf: &mut [u8]) -> Self {
+        let remaining_body_len = total_packet_len - PACKET_HEADER_LENGTH;
+
+        Self::zero_packet_header(packet_recv_buf);
+
+        Self {
+            remaining_body_len,
+            already_read_len: 0,
+            total_packet_len,
+        }
+    }
+
+    pub(crate) fn direct_read_len(&self) -> Option<usize> {
+        if self.total_packet_len < MAX_SEGMENT_READ && self.total_packet_len > 0
+        {
+            Some(self.total_packet_len)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn finish_direct_read(
+        &mut self,
+        already_read_len: usize,
+    ) -> usize {
+        self.already_read_len = already_read_len;
+        self.already_read_len
+    }
+
+    pub(crate) fn has_remaining_segments(&self) -> bool {
+        self.remaining_body_len > 0
+    }
+
+    pub(crate) fn next_segment_read_len(&self) -> usize {
+        let whole_segment_length =
+            self.remaining_body_len + PACKET_HEADER_LENGTH;
+        if whole_segment_length > MAX_SEGMENT_READ {
+            MAX_SEGMENT_READ
+        } else {
+            whole_segment_length
+        }
+    }
+
+    pub(crate) fn transcribe_segment(
+        &mut self,
+        segment_read_len: usize,
+        seg_recv_buf: &[u8],
+        packet_recv_buf: &mut [u8],
+    ) {
+        let transcribe_start_idx = if self.already_read_len > 0 {
+            PACKET_HEADER_LENGTH
+        } else {
+            0
+        };
+        let transcribe_len = if self.already_read_len > 0 {
+            segment_read_len - PACKET_HEADER_LENGTH
+        } else {
+            segment_read_len
+        };
+
+        packet_recv_buf
+            [self.already_read_len..self.already_read_len + transcribe_len]
+            .copy_from_slice(
+                &seg_recv_buf[transcribe_start_idx
+                    ..transcribe_start_idx + transcribe_len],
+            );
+        self.already_read_len += transcribe_len;
+
+        let body_read_len = segment_read_len - PACKET_HEADER_LENGTH;
+        self.remaining_body_len -= body_read_len;
+    }
+
+    pub(crate) fn already_read_len(&self) -> usize {
+        self.already_read_len
+    }
+
+    fn zero_packet_header(packet_recv_buf: &mut [u8]) {
+        for byte in &mut packet_recv_buf[..PACKET_HEADER_LENGTH] {
+            *byte = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_recv_packet_header_only_clears_header() {
+        let mut common = I2cCommon::new(DEFAULT_ADDRESS);
+        common.seg_recv_buf[..8].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+
+        common.zero_recv_packet_header();
+
+        assert_eq!(&common.seg_recv_buf[..8], &[0, 0, 0, 0, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn segmented_read_transcribes_first_header_then_body_only() {
+        let total_packet_len = 276;
+        let mut recv_buf = [0xAA; 276];
+        let mut read = I2cCommon::sized_read(total_packet_len, &mut recv_buf);
+
+        let first_segment_len = read.next_segment_read_len();
+        assert_eq!(first_segment_len, MAX_SEGMENT_READ);
+
+        let mut first_segment = [0; SEG_RECV_BUF_LEN];
+        for (idx, byte) in
+            first_segment[..first_segment_len].iter_mut().enumerate()
+        {
+            *byte = idx as u8;
+        }
+        read.transcribe_segment(
+            first_segment_len,
+            &first_segment,
+            &mut recv_buf,
+        );
+        assert_eq!(read.already_read_len(), MAX_SEGMENT_READ);
+        assert_eq!(&recv_buf[..6], &[0, 1, 2, 3, 4, 5]);
+
+        let second_segment_len = read.next_segment_read_len();
+        assert_eq!(second_segment_len, 40);
+
+        let mut second_segment = [0; SEG_RECV_BUF_LEN];
+        second_segment[..second_segment_len].fill(0xEE);
+        second_segment[PACKET_HEADER_LENGTH..second_segment_len].fill(0xBB);
+        read.transcribe_segment(
+            second_segment_len,
+            &second_segment,
+            &mut recv_buf,
+        );
+
+        assert_eq!(read.already_read_len(), total_packet_len);
+        assert_eq!(&recv_buf[240..276], &[0xBB; 36]);
+        assert!(!read.has_remaining_segments());
+    }
+
+    #[test]
+    fn record_received_packet_ignores_zero_length_packets() {
+        let mut common = I2cCommon::new(DEFAULT_ADDRESS);
+
+        common.record_received_packet(0);
+        common.record_received_packet(4);
+        common.record_received_packet(0);
+        common.record_received_packet(12);
+
+        assert_eq!(common.received_packet_count, 2);
+    }
+}

--- a/src/interface/mock_i2c_port.rs
+++ b/src/interface/mock_i2c_port.rs
@@ -3,16 +3,8 @@ extern crate std;
 use super::PACKET_HEADER_LENGTH;
 
 use core::ops::Shr;
-use embedded_hal::i2c::I2c;
+use embedded_hal::i2c::{I2c, Operation};
 use std::collections::VecDeque;
-
-// struct FakeDelay {}
-
-// impl DelayMs<u8> for FakeDelay {
-//     fn delay_ms(&mut self, _ms: u8) {
-//         // no-op
-//     }
-// }
 
 const MAX_FAKE_PACKET_SIZE: usize = 512;
 
@@ -41,6 +33,19 @@ pub struct FakeI2cPort {
     pub sent_packets: VecDeque<FakePacket>,
 }
 
+#[derive(Debug)]
+pub struct FakeI2cError;
+
+impl embedded_hal::i2c::Error for FakeI2cError {
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
+        embedded_hal::i2c::ErrorKind::Other
+    }
+}
+
+impl embedded_hal::i2c::ErrorType for FakeI2cPort {
+    type Error = FakeI2cError;
+}
+
 impl FakeI2cPort {
     pub fn new() -> Self {
         FakeI2cPort {
@@ -54,10 +59,12 @@ impl FakeI2cPort {
         let pack = FakePacket::new_from_slice(bytes);
         self.available_packets.push_back(pack);
     }
-}
 
-impl I2c for FakeI2cPort {
-    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+    fn handle_read(
+        &mut self,
+        addr: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), FakeI2cError> {
         let next_pack =
             self.available_packets.pop_front().unwrap_or(FakePacket {
                 addr: addr,
@@ -90,7 +97,8 @@ impl I2c for FakeI2cPort {
                 );
             remainder_packet.buf[0] = ((remainder_len + 4) & 0xFF) as u8;
             remainder_packet.buf[1] =
-                ((((remainder_len + 4) & 0xFF00) as u16).shr(8) as u8) | 0x80; //set continuation flag
+                ((((remainder_len + 4) & 0xFF00) as u16).shr(8) as u8)
+                    | 0x80; //set continuation flag
             self.available_packets.push_front(remainder_packet);
         } else if src_len == dest_len {
             let read_len = src_len;
@@ -102,31 +110,34 @@ impl I2c for FakeI2cPort {
 
         Ok(())
     }
+
+    fn handle_write(
+        &mut self,
+        _addr: u8,
+        bytes: &[u8],
+    ) -> Result<(), FakeI2cError> {
+        let sent_pack = FakePacket::new_from_slice(bytes);
+        self.sent_packets.push_back(sent_pack);
+        Ok(())
+    }
 }
 
 impl I2c for FakeI2cPort {
     fn transaction(
         &mut self,
         address: u8,
-        operations: &mut [embedded_hal::i2c::Operation<'_>],
+        operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error> {
-        let sent_pack = FakePacket::new_from_slice(_bytes);
-        self.sent_packets.push_back(sent_pack);
-        Ok(())
-    }
-}
-
-impl WriteRead for FakeI2cPort {
-    type Error = ();
-
-    fn write_read(
-        &mut self,
-        address: u8,
-        send_buf: &[u8],
-        recv_buf: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        self.write(address, send_buf)?;
-        self.read(address, recv_buf)?;
+        for op in operations {
+            match op {
+                Operation::Read(buf) => {
+                    self.handle_read(address, buf)?;
+                }
+                Operation::Write(buf) => {
+                    self.handle_write(address, buf)?;
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,6 +1,12 @@
 pub mod i2c;
 pub mod spi;
 
+#[cfg(feature = "async")]
+pub mod i2c_async;
+
+#[cfg(feature = "async")]
+use embedded_hal_async::delay::DelayNs as DelayNsAsync;
+
 #[cfg(test)]
 pub mod mock_i2c_port;
 
@@ -51,7 +57,54 @@ pub trait SensorInterface {
     fn requires_soft_reset(&self) -> bool;
 }
 
+#[cfg(feature = "async")]
+#[allow(async_fn_in_trait)]
+pub trait SensorInterfaceAsync {
+    /// Interface error type
+    type SensorError;
+
+    /// give the sensor interface a chance to set up
+    async fn setup(
+        &mut self,
+        delay_source: &mut impl DelayNsAsync,
+    ) -> Result<(), Self::SensorError>;
+
+    /// Write the whole packet provided
+    async fn write_packet(
+        &mut self,
+        packet: &[u8],
+    ) -> Result<(), Self::SensorError>;
+
+    /// Read the next packet from the sensor
+    /// Returns the size of the packet read (up to the size of the slice provided)
+    async fn read_packet(
+        &mut self,
+        recv_buf: &mut [u8],
+    ) -> Result<usize, Self::SensorError>;
+
+    /// Wait for sensor to indicate it has data available before reading
+    /// - `max_ms` maximum number of milliseconds to wait for data
+    async fn read_with_timeout(
+        &mut self,
+        recv_buf: &mut [u8],
+        delay_source: &mut impl DelayNsAsync,
+        max_ms: u8,
+    ) -> Result<usize, Self::SensorError>;
+
+    /// Send a packet and receive the response immediately
+    async fn send_and_receive_packet(
+        &mut self,
+        send_buf: &[u8],
+        recv_buf: &mut [u8],
+    ) -> Result<usize, Self::SensorError>;
+
+    /// Does this interface require a soft reset after init?
+    fn requires_soft_reset(&self) -> bool;
+}
+
 pub use self::i2c::I2cInterface;
+#[cfg(feature = "async")]
+pub use self::i2c_async::I2cInterfaceAsync;
 pub use self::spi::SpiInterface;
 
 pub(crate) const PACKET_HEADER_LENGTH: usize = 4;

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,4 +1,5 @@
 pub mod i2c;
+mod i2c_common;
 pub mod spi;
 
 #[cfg(feature = "async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ LICENSE: BSD3 (see LICENSE file)
 
 pub mod interface;
 pub mod wrapper;
+#[cfg(feature = "async")]
+pub mod wrapper_async;
 
 /// Errors in this crate
 #[derive(Debug)]

--- a/src/wrapper_async.rs
+++ b/src/wrapper_async.rs
@@ -1,0 +1,823 @@
+/*
+Copyright (c) 2026 Aleksandar Bukva
+LICENSE: BSD3 (see LICENSE file)
+*/
+
+use crate::interface::{SensorInterfaceAsync, PACKET_HEADER_LENGTH};
+
+use core::ops::Shr;
+
+use embedded_hal_async::delay::DelayNs;
+#[cfg(feature = "rttdebug")]
+use panic_rtt_core::rprintln;
+
+const PACKET_SEND_BUF_LEN: usize = 256;
+const PACKET_RECV_BUF_LEN: usize = 1024;
+
+const NUM_CHANNELS: usize = 6;
+
+#[derive(Debug)]
+pub enum WrapperError<E> {
+    ///Communications error
+    CommError(E),
+    /// Invalid chip ID was read
+    InvalidChipId(u8),
+    /// Unsupported sensor firmware version
+    InvalidFWVersion(u8),
+    /// We expected some data but didn't receive any
+    NoDataAvailable,
+}
+
+pub struct BNO080Async<SI> {
+    pub(crate) sensor_interface: SI,
+    /// each communication channel with the device has its own sequence number
+    sequence_numbers: [u8; NUM_CHANNELS],
+    /// buffer for building and sending packet to the sensor hub
+    packet_send_buf: [u8; PACKET_SEND_BUF_LEN],
+    /// buffer for building packets received from the sensor hub
+    packet_recv_buf: [u8; PACKET_RECV_BUF_LEN],
+
+    last_packet_len_received: usize,
+    /// has the device been succesfully reset
+    device_reset: bool,
+    /// has the product ID been verified
+    prod_id_verified: bool,
+
+    init_received: bool,
+
+    /// have we received the full advertisement
+    advert_received: bool,
+
+    /// have we received an error list
+    error_list_received: bool,
+    last_error_received: u8,
+
+    last_chan_received: u8,
+    last_exec_chan_rid: u8,
+    last_command_chan_rid: u8,
+
+    /// Rotation vector as unit quaternion
+    rotation_quaternion: [f32; 4],
+    /// Heading accuracy of rotation vector (radians)
+    rot_quaternion_acc: f32,
+
+    /// Linear acceleration vector
+    linear_accel: [f32; 3],
+
+    /// Gyroscope calibrated data
+    gyro: [f32; 3],
+}
+
+impl<SI> BNO080Async<SI> {
+    pub fn new_with_interface(sensor_interface: SI) -> Self {
+        Self {
+            sensor_interface,
+            sequence_numbers: [0; NUM_CHANNELS],
+            packet_send_buf: [0; PACKET_SEND_BUF_LEN],
+            packet_recv_buf: [0; PACKET_RECV_BUF_LEN],
+            last_packet_len_received: 0,
+            device_reset: false,
+            prod_id_verified: false,
+            init_received: false,
+            advert_received: false,
+            error_list_received: false,
+            last_error_received: 0,
+            last_chan_received: 0,
+            last_exec_chan_rid: 0,
+            last_command_chan_rid: 0,
+            rotation_quaternion: [0.0; 4],
+            rot_quaternion_acc: 0.0,
+            linear_accel: [0.0; 3],
+            gyro: [0.0; 3],
+        }
+    }
+
+    /// Returns previously consumed serial sensor instance.
+    pub fn free(self) -> SI {
+        self.sensor_interface
+    }
+}
+
+impl<SI, SE> BNO080Async<SI>
+where
+    SI: SensorInterfaceAsync<SensorError = SE>,
+    SE: core::fmt::Debug,
+{
+    /// Consume all available messages on the port without processing them
+    pub async fn eat_all_messages(&mut self, delay: &mut impl DelayNs) {
+        #[cfg(feature = "rttdebug")]
+        rprintln!("eat_n");
+        loop {
+            let msg_count = self.eat_one_message(delay).await;
+            if msg_count == 0 {
+                break;
+            }
+            //give some time to other parts of the system
+            delay.delay_ms(1).await;
+        }
+    }
+
+    /// Handle any messages with a timeout
+    pub async fn handle_all_messages(
+        &mut self,
+        delay: &mut impl DelayNs,
+        timeout_ms: u8,
+    ) -> u32 {
+        let mut total_handled: u32 = 0;
+        loop {
+            let handled_count =
+                self.handle_one_message(delay, timeout_ms).await;
+            if handled_count == 0 {
+                break;
+            } else {
+                total_handled += handled_count;
+                //give some time to other parts of the system
+                delay.delay_ms(1).await;
+            }
+        }
+        total_handled
+    }
+
+    /// return the number of messages handled
+    pub async fn handle_one_message(
+        &mut self,
+        delay: &mut impl DelayNs,
+        max_ms: u8,
+    ) -> u32 {
+        let mut msg_count = 0;
+
+        let res = self.receive_packet_with_timeout(delay, max_ms).await;
+        if res.is_ok() {
+            let received_len = res.unwrap_or(0);
+            if received_len > 0 {
+                msg_count += 1;
+                self.handle_received_packet(received_len);
+            }
+        } else {
+            #[cfg(feature = "rttdebug")]
+            rprintln!("handle1 err {:?}", res);
+        }
+
+        msg_count
+    }
+
+    /// Receive and ignore one message,
+    /// returning the size of the packet received or zero
+    /// if there was no packet to read.
+    pub async fn eat_one_message(&mut self, delay: &mut impl DelayNs) -> usize {
+        let res = self.receive_packet_with_timeout(delay, 150).await;
+        if let Ok(received_len) = res {
+            #[cfg(feature = "rttdebug")]
+            rprintln!("e1 {}", received_len);
+            received_len
+        } else {
+            #[cfg(feature = "rttdebug")]
+            rprintln!("e1 err {:?}", res);
+            0
+        }
+    }
+
+    fn handle_advertise_response(&mut self, received_len: usize) {
+        let payload_len = received_len - PACKET_HEADER_LENGTH;
+        let payload = &self.packet_recv_buf[PACKET_HEADER_LENGTH..received_len];
+        let mut cursor: usize = 1; //skip response type
+
+        #[cfg(feature = "rttdebug")]
+        rprintln!("AdvRsp: {}", payload_len);
+
+        while cursor < payload_len {
+            let _tag: u8 = payload[cursor];
+            cursor += 1;
+            let len: u8 = payload[cursor];
+            cursor += 1;
+            //let val: u8 = payload + cursor;
+            cursor += len as usize;
+        }
+
+        self.advert_received = true;
+    }
+
+    fn read_u8_at_cursor(msg: &[u8], cursor: &mut usize) -> u8 {
+        let val = msg[*cursor];
+        *cursor += 1;
+        val
+    }
+
+    fn read_i16_at_cursor(msg: &[u8], cursor: &mut usize) -> i16 {
+        let val = (msg[*cursor] as i16) | ((msg[*cursor + 1] as i16) << 8);
+        *cursor += 2;
+        val
+    }
+
+    fn try_read_i16_at_cursor(msg: &[u8], cursor: &mut usize) -> Option<i16> {
+        let remaining = msg.len() - *cursor;
+        if remaining >= 2 {
+            let val = (msg[*cursor] as i16) | ((msg[*cursor + 1] as i16) << 8);
+            *cursor += 2;
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    /// Read data values from a single input report
+    fn handle_one_input_report(
+        outer_cursor: usize,
+        msg: &[u8],
+    ) -> (usize, u8, i16, i16, i16, i16, i16) {
+        let mut cursor = outer_cursor;
+
+        let feature_report_id = Self::read_u8_at_cursor(msg, &mut cursor);
+        let _rep_seq_num = Self::read_u8_at_cursor(msg, &mut cursor);
+        let _rep_status = Self::read_u8_at_cursor(msg, &mut cursor);
+        let _delay = Self::read_u8_at_cursor(msg, &mut cursor);
+
+        let data1: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
+        let data2: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
+        let data3: i16 = Self::read_i16_at_cursor(msg, &mut cursor);
+        let data4: i16 =
+            Self::try_read_i16_at_cursor(msg, &mut cursor).unwrap_or(0);
+        let data5: i16 =
+            Self::try_read_i16_at_cursor(msg, &mut cursor).unwrap_or(0);
+
+        (cursor, feature_report_id, data1, data2, data3, data4, data5)
+    }
+
+    /// Handle parsing of an input report packet,
+    /// which may include multiple input reports
+    fn handle_sensor_reports(&mut self, received_len: usize) {
+        // Sensor input packets have the form:
+        // [u8; 5]  timestamp in microseconds for the packet?
+        // a sequence of n reports, each with four byte header
+        // u8 report ID
+        // u8 sequence number of report
+
+        // let mut report_count = 0;
+        let mut outer_cursor: usize = PACKET_HEADER_LENGTH + 5; //skip header, timestamp
+                                                                //TODO need to skip more above for a payload-level timestamp??
+        if received_len < outer_cursor {
+            #[cfg(feature = "rttdebug")]
+            rprintln!("bad lens: {} < {}", received_len, outer_cursor);
+            return;
+        }
+
+        let payload_len = received_len - outer_cursor;
+        if payload_len < 14 {
+            #[cfg(feature = "rttdebug")]
+            rprintln!(
+                "bad report: {:?}",
+                &self.packet_recv_buf[..PACKET_HEADER_LENGTH]
+            );
+
+            return;
+        }
+
+        // there may be multiple reports per payload
+        while outer_cursor < payload_len {
+            //let start_cursor = outer_cursor;
+            let (inner_cursor, report_id, data1, data2, data3, data4, data5) =
+                Self::handle_one_input_report(
+                    outer_cursor,
+                    &self.packet_recv_buf[..received_len],
+                );
+            outer_cursor = inner_cursor;
+            // report_count += 1;
+            match report_id {
+                SENSOR_REPORTID_ROTATION_VECTOR => {
+                    self.update_rotation_quaternion(
+                        data1, data2, data3, data4, data5,
+                    );
+                }
+                SENSOR_REPORTID_LINEAR_ACCEL => {
+                    self.update_linear_accel(data1, data2, data3);
+                }
+                SENSOR_REPORTID_GYRO => {
+                    self.update_gyro_cal(data1, data2, data3);
+                }
+                _ => {
+                    // debug_println!("uhr: {:X}", report_id);
+                    // debug_println!("uhr: 0x{:X} {:?}  ", report_id, &self.packet_recv_buf[start_cursor..start_cursor+5]);
+                }
+            }
+        }
+
+        //debug_println!("report_count: {}",report_count);
+    }
+
+    /// Given a set of quaternion values in the Q-fixed-point format,
+    /// calculate and update the corresponding float values
+    fn update_rotation_quaternion(
+        &mut self,
+        q_i: i16,
+        q_j: i16,
+        q_k: i16,
+        q_r: i16,
+        q_a: i16,
+    ) {
+        //debug_println!("rquat {} {} {} {} {}", q_i, q_j, q_k, q_r, q_a);
+        self.rotation_quaternion = [
+            q14_to_f32(q_i),
+            q14_to_f32(q_j),
+            q14_to_f32(q_k),
+            q14_to_f32(q_r),
+        ];
+        self.rot_quaternion_acc = q12_to_f32(q_a);
+    }
+
+    /// Given a set of linear acceleration values in the Q-fixed-point format,
+    /// calculate and update the corresponding float values
+    fn update_linear_accel(&mut self, x: i16, y: i16, z: i16) {
+        let x = q8_to_f32(x);
+        let y = q8_to_f32(y);
+        let z = q8_to_f32(z);
+
+        self.linear_accel = [x, y, z];
+    }
+
+    /// Given a set of linear acceleration values in the Q-fixed-point format,
+    /// calculate and update the corresponding float values
+    fn update_gyro_cal(&mut self, x: i16, y: i16, z: i16) {
+        let x = q9_to_f32(x);
+        let y = q9_to_f32(y);
+        let z = q9_to_f32(z);
+
+        self.gyro = [x, y, z];
+    }
+
+    /// Handle one or more errors sent in response to a command
+    fn handle_cmd_resp_error_list(&mut self, received_len: usize) {
+        let payload_len = received_len - PACKET_HEADER_LENGTH;
+        let payload = &self.packet_recv_buf[PACKET_HEADER_LENGTH..received_len];
+
+        self.error_list_received = true;
+        for cursor in 1..payload_len {
+            let err: u8 = payload[cursor];
+            self.last_error_received = err;
+            #[cfg(feature = "rttdebug")]
+            rprintln!("lerr: {:x}", err);
+        }
+    }
+
+    pub fn handle_received_packet(&mut self, received_len: usize) {
+        let msg = &self.packet_recv_buf[..received_len];
+        let chan_num = msg[2];
+        //let _seq_num =  msg[3];
+        let report_id: u8 = if received_len > PACKET_HEADER_LENGTH {
+            msg[4]
+        } else {
+            0
+        };
+
+        self.last_chan_received = chan_num;
+        match chan_num {
+            CHANNEL_COMMAND => match report_id {
+                CMD_RESP_ADVERTISEMENT => {
+                    self.handle_advertise_response(received_len);
+                }
+                CMD_RESP_ERROR_LIST => {
+                    self.handle_cmd_resp_error_list(received_len);
+                }
+                _ => {
+                    self.last_command_chan_rid = report_id;
+                    #[cfg(feature = "rttdebug")]
+                    rprintln!("unh cmd: {}", report_id);
+                }
+            },
+            CHANNEL_EXECUTABLE => match report_id {
+                EXECUTABLE_DEVICE_RESP_RESET_COMPLETE => {
+                    self.device_reset = true;
+                    #[cfg(feature = "rttdebug")]
+                    rprintln!("resp_reset {}", 1);
+                }
+                _ => {
+                    self.last_exec_chan_rid = report_id;
+                    #[cfg(feature = "rttdebug")]
+                    rprintln!("unh exe: {:x}", report_id);
+                }
+            },
+            CHANNEL_HUB_CONTROL => {
+                match report_id {
+                    SHUB_COMMAND_RESP => {
+                        // 0xF1 / 241
+                        let cmd_resp = msg[6];
+                        if cmd_resp == SH2_STARTUP_INIT_UNSOLICITED {
+                            self.init_received = true;
+                        } else if cmd_resp == SH2_INIT_SYSTEM {
+                            self.init_received = true;
+                        }
+                        #[cfg(feature = "rttdebug")]
+                        rprintln!("CMD_RESP: 0x{:X}", cmd_resp);
+                    }
+                    SHUB_PROD_ID_RESP => {
+                        #[cfg(feature = "rttdebug")]
+                        {
+                            //let reset_cause = msg[4 + 1];
+                            let sw_vers_major = msg[4 + 2];
+                            let sw_vers_minor = msg[4 + 3];
+                            rprintln!(
+                                "PID_RESP {}.{}",
+                                sw_vers_major,
+                                sw_vers_minor
+                            );
+                        }
+
+                        self.prod_id_verified = true;
+                    }
+                    SHUB_GET_FEATURE_RESP => {
+                        // 0xFC
+                        #[cfg(feature = "rttdebug")]
+                        rprintln!("feat resp: {}", msg[5]);
+                    }
+                    _ => {
+                        #[cfg(feature = "rttdebug")]
+                        rprintln!(
+                            "unh hbc: 0x{:X} {:x?}",
+                            report_id,
+                            &msg[..PACKET_HEADER_LENGTH]
+                        );
+                    }
+                }
+            }
+            CHANNEL_SENSOR_REPORTS => {
+                self.handle_sensor_reports(received_len);
+            }
+            _ => {
+                self.last_chan_received = chan_num;
+                #[cfg(feature = "rttdebug")]
+                rprintln!("unh chan 0x{:X}", chan_num);
+            }
+        }
+    }
+
+    /// The BNO080 starts up with all sensors disabled,
+    /// waiting for the application to configure it.
+    pub async fn init(
+        &mut self,
+        delay_source: &mut impl DelayNs,
+    ) -> Result<(), WrapperError<SE>> {
+        #[cfg(feature = "rttdebug")]
+        rprintln!("wrapper init");
+
+        //Section 5.1.1.1 : On system startup, the SHTP control application will send
+        // its full advertisement response, unsolicited, to the host.
+        delay_source.delay_ms(1).await;
+        self.sensor_interface
+            .setup(delay_source)
+            .await
+            .map_err(WrapperError::CommError)?;
+
+        if self.sensor_interface.requires_soft_reset() {
+            delay_source.delay_ms(1).await;
+            self.soft_reset().await?;
+            delay_source.delay_ms(150).await;
+            self.eat_all_messages(delay_source).await;
+            delay_source.delay_ms(50).await;
+            self.eat_all_messages(delay_source).await;
+        } else {
+            // we only expect two messages after reset:
+            // eat the advertisement response
+            self.eat_one_message(delay_source).await;
+            // eat the unsolicited initialization response
+            self.eat_one_message(delay_source).await;
+        }
+
+        self.verify_product_id(delay_source).await?;
+        //self.eat_all_messages(delay_source);
+
+        Ok(())
+    }
+
+    /// Tell the sensor to start reporting the fused rotation vector
+    /// on a regular cadence. Note that the maximum valid update rate
+    /// is 1 kHz, based on the max update rate of the sensor's gyros.
+    pub async fn enable_rotation_vector(
+        &mut self,
+        millis_between_reports: u16,
+    ) -> Result<(), WrapperError<SE>> {
+        self.enable_report(
+            SENSOR_REPORTID_ROTATION_VECTOR,
+            millis_between_reports,
+        )
+        .await
+    }
+
+    /// Enables reporting of linear acceleration vector.
+    pub async fn enable_linear_accel(
+        &mut self,
+        millis_between_reports: u16,
+    ) -> Result<(), WrapperError<SE>> {
+        self.enable_report(SENSOR_REPORTID_LINEAR_ACCEL, millis_between_reports)
+            .await
+    }
+
+    /// Enables reporting of gyroscope data.
+    pub async fn enable_gyro(
+        &mut self,
+        millis_between_reports: u16,
+    ) -> Result<(), WrapperError<SE>> {
+        self.enable_report(SENSOR_REPORTID_GYRO, millis_between_reports)
+            .await
+    }
+
+    /// Enable a particular report
+    async fn enable_report(
+        &mut self,
+        report_id: u8,
+        millis_between_reports: u16,
+    ) -> Result<(), WrapperError<SE>> {
+        #[cfg(feature = "rttdebug")]
+        rprintln!("enable_report 0x{:X}", report_id);
+
+        let micros_between_reports: u32 =
+            (millis_between_reports as u32) * 1000;
+        let cmd_body: [u8; 17] = [
+            SHUB_REPORT_SET_FEATURE_CMD,
+            report_id,
+            0,                                        //feature flags
+            0,                                        //LSB change sensitivity
+            0,                                        //MSB change sensitivity
+            (micros_between_reports & 0xFFu32) as u8, // LSB report interval, microseconds
+            (micros_between_reports.shr(8) & 0xFFu32) as u8,
+            (micros_between_reports.shr(16) & 0xFFu32) as u8,
+            (micros_between_reports.shr(24) & 0xFFu32) as u8, // MSB report interval
+            0, // LSB Batch Interval
+            0,
+            0,
+            0, // MSB Batch interval
+            0, // LSB sensor-specific config
+            0,
+            0,
+            0, // MSB sensor-specific config
+        ];
+
+        //we simply blast out this configuration command and assume it'll succeed
+        self.send_packet(CHANNEL_HUB_CONTROL, &cmd_body).await?;
+        // any error or success in configuration will arrive some time later
+
+        Ok(())
+    }
+
+    /// Prepare a packet for sending, in our send buffer
+    fn prep_send_packet(&mut self, channel: u8, body_data: &[u8]) -> usize {
+        let body_len = body_data.len();
+
+        let packet_length = body_len + PACKET_HEADER_LENGTH;
+        let packet_header = [
+            (packet_length & 0xFF) as u8, //LSB
+            packet_length.shr(8) as u8,   //MSB
+            channel,
+            self.sequence_numbers[channel as usize],
+        ];
+        self.sequence_numbers[channel as usize] += 1;
+
+        self.packet_send_buf[..PACKET_HEADER_LENGTH]
+            .copy_from_slice(packet_header.as_ref());
+        self.packet_send_buf[PACKET_HEADER_LENGTH..packet_length]
+            .copy_from_slice(body_data);
+
+        packet_length
+    }
+
+    /// Send packet from our packet send buf
+    async fn send_packet(
+        &mut self,
+        channel: u8,
+        body_data: &[u8],
+    ) -> Result<usize, WrapperError<SE>> {
+        let packet_length = self.prep_send_packet(channel, body_data);
+        self.sensor_interface
+            .write_packet(&self.packet_send_buf[..packet_length])
+            .await
+            .map_err(WrapperError::CommError)?;
+        Ok(packet_length)
+    }
+
+    /// Read one packet into the receive buffer
+    pub(crate) async fn receive_packet_with_timeout(
+        &mut self,
+        delay: &mut impl DelayNs,
+        max_ms: u8,
+    ) -> Result<usize, WrapperError<SE>> {
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("r_p");
+
+        self.packet_recv_buf[0] = 0;
+        self.packet_recv_buf[1] = 0;
+        let packet_len = self
+            .sensor_interface
+            .read_with_timeout(&mut self.packet_recv_buf, delay, max_ms)
+            .await
+            .map_err(WrapperError::CommError)?;
+
+        self.last_packet_len_received = packet_len;
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("recv {}", packet_len);
+
+        Ok(packet_len)
+    }
+
+    /// Verify that the sensor returns an expected chip ID
+    async fn verify_product_id(
+        &mut self,
+        delay: &mut impl DelayNs,
+    ) -> Result<(), WrapperError<SE>> {
+        #[cfg(feature = "rttdebug")]
+        rprintln!("request PID...");
+        let cmd_body: [u8; 2] = [
+            SHUB_PROD_ID_REQ, //request product ID
+            0,                //reserved
+        ];
+
+        // for some reason, reading PID right sending request does not work with i2c
+        if self.sensor_interface.requires_soft_reset() {
+            self.send_packet(CHANNEL_HUB_CONTROL, cmd_body.as_ref())
+                .await?;
+        } else {
+            let response_size = self
+                .send_and_receive_packet(CHANNEL_HUB_CONTROL, cmd_body.as_ref())
+                .await?;
+            if response_size > 0 {
+                self.handle_received_packet(response_size);
+            }
+        };
+
+        // process all incoming messages until we get a product id (or no more data)
+        while !self.prod_id_verified {
+            #[cfg(feature = "rttdebug")]
+            rprintln!("read PID");
+            let msg_count = self.handle_one_message(delay, 150u8).await;
+            if msg_count < 1 {
+                break;
+            }
+        }
+
+        if !self.prod_id_verified {
+            return Err(WrapperError::InvalidChipId(0));
+        }
+        Ok(())
+    }
+
+    /// Read normalized quaternion:
+    /// QX normalized quaternion – X, or Heading | range: 0.0 – 1.0 ( ±π )
+    /// QY normalized quaternion – Y, or Pitch   | range: 0.0 – 1.0 ( ±π/2 )
+    /// QZ normalized quaternion – Z, or Roll    | range: 0.0 – 1.0 ( ±π )
+    /// QW normalized quaternion – W, or 0.0     | range: 0.0 – 1.0
+    pub fn rotation_quaternion(&self) -> Result<[f32; 4], WrapperError<SE>> {
+        Ok(self.rotation_quaternion)
+    }
+
+    pub fn heading_accuracy(&self) -> f32 {
+        self.rot_quaternion_acc
+    }
+
+    /// Read linear acceleration (m/s^2)
+    pub fn linear_accel(&self) -> Result<[f32; 3], WrapperError<SE>> {
+        Ok(self.linear_accel)
+    }
+
+    /// Read gyroscope data (rad/s)
+    pub fn gyro(&self) -> Result<[f32; 3], WrapperError<SE>> {
+        Ok(self.gyro)
+    }
+
+    /// Tell the sensor to reset.
+    /// Normally applications should not need to call this directly,
+    /// as it is called during `init`.
+    pub async fn soft_reset(&mut self) -> Result<(), WrapperError<SE>> {
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("soft_reset");
+        let data: [u8; 1] = [EXECUTABLE_DEVICE_CMD_RESET];
+        // send command packet and ignore received packets
+        let received_len = self
+            .send_and_receive_packet(CHANNEL_EXECUTABLE, data.as_ref())
+            .await?;
+        if received_len > 0 {
+            self.handle_received_packet(received_len);
+        }
+
+        Ok(())
+    }
+
+    /// Send a packet and receive the response
+    async fn send_and_receive_packet(
+        &mut self,
+        channel: u8,
+        body_data: &[u8],
+    ) -> Result<usize, WrapperError<SE>> {
+        let send_packet_length = self.prep_send_packet(channel, body_data);
+        // #[cfg(feature = "rttdebug")]
+        // rprintln!("srcv {} ...", send_packet_length);
+
+        let recv_packet_length = self
+            .sensor_interface
+            .send_and_receive_packet(
+                self.packet_send_buf[..send_packet_length].as_ref(),
+                &mut self.packet_recv_buf,
+            )
+            .await
+            .map_err(WrapperError::CommError)?;
+
+        #[cfg(feature = "rttdebug")]
+        rprintln!("srcv {} {}", send_packet_length, recv_packet_length);
+
+        Ok(recv_packet_length)
+    }
+}
+
+const Q8_SCALE: f32 = 1.0 / ((1 << 8) as f32);
+const Q9_SCALE: f32 = 1.0 / ((1 << 9) as f32);
+const Q12_SCALE: f32 = 1.0 / ((1 << 12) as f32);
+const Q14_SCALE: f32 = 1.0 / ((1 << 14) as f32);
+
+fn q14_to_f32(q_val: i16) -> f32 {
+    // let qq_val =  fpa::I2F14(q_val).unwrap();
+    // return f32(qq_val)
+    (q_val as f32) * Q14_SCALE
+}
+
+fn q12_to_f32(q_val: i16) -> f32 {
+    (q_val as f32) * Q12_SCALE
+}
+
+fn q8_to_f32(q_val: i16) -> f32 {
+    (q_val as f32) * Q8_SCALE
+}
+
+fn q9_to_f32(q_val: i16) -> f32 {
+    (q_val as f32) * Q9_SCALE
+}
+
+// The BNO080 supports six communication channels:
+const CHANNEL_COMMAND: u8 = 0;
+/// the SHTP command channel
+const CHANNEL_EXECUTABLE: u8 = 1;
+/// executable channel
+const CHANNEL_HUB_CONTROL: u8 = 2;
+/// sensor hub control channel
+const CHANNEL_SENSOR_REPORTS: u8 = 3;
+/// input sensor reports (non-wake, not gyroRV)
+//const  CHANNEL_WAKE_REPORTS: usize = 4; /// wake input sensor reports (for sensors configured as wake up sensors)
+//const  CHANNEL_GYRO_ROTATION: usize = 5; ///  gyro rotation vector (gyroRV)
+
+/// Command Channel requests / responses
+
+// Commands
+//const CMD_GET_ADVERTISEMENT: u8 = 0;
+//const CMD_SEND_ERROR_LIST: u8 = 1;
+
+/// Responses
+const CMD_RESP_ADVERTISEMENT: u8 = 0;
+const CMD_RESP_ERROR_LIST: u8 = 1;
+
+/// SHTP constants
+
+/// Report ID for Product ID request
+const SHUB_PROD_ID_REQ: u8 = 0xF9;
+/// Report ID for Product ID response
+const SHUB_PROD_ID_RESP: u8 = 0xF8;
+const SHUB_GET_FEATURE_RESP: u8 = 0xFC;
+const SHUB_REPORT_SET_FEATURE_CMD: u8 = 0xFD;
+// const SHUB_GET_FEATURE_REQ: u8 = 0xFE;
+// const SHUB_FORCE_SENSOR_FLUSH: u8 = 0xF0;
+const SHUB_COMMAND_RESP: u8 = 0xF1;
+//const SHUB_COMMAND_REQ:u8 =  0xF2;
+
+// some mysterious responses we sometimes get:
+// 0x78, 0x7C
+
+/// Report IDs from SH2 Reference Manual:
+// 0x01 accelerometer (m/s^2 including gravity): Q point 8
+// 0x02 gyroscope calibrated (rad/s): Q point 9
+// 0x03 mag field calibrated (uTesla): Q point 4
+/// Linear acceleration (m/s^2 minus gravity): Q point 8
+const SENSOR_REPORTID_LINEAR_ACCEL: u8 = 0x04;
+
+/// Unit quaternion rotation vector, Q point 12, with heading accuracy estimate (radians)
+const SENSOR_REPORTID_ROTATION_VECTOR: u8 = 0x05;
+// const SENSOR_REPORTID_GRAVITY: u8 = 0x06; // Q point 8
+/// Gyroscope uncalibrated (rad/s): Q point 9
+const SENSOR_REPORTID_GYRO: u8 = 0x07;
+// 0x08 game rotation vector : Q point 14
+// 0x09 geomagnetic rotation vector: Q point 14 for quaternion, Q point 12 for heading accuracy
+// 0x0A pressure (hectopascals) from external baro: Q point 20
+// 0x0B ambient light (lux) from external sensor: Q point 8
+// 0x0C humidity (percent) from external sensor: Q point 8
+// 0x0D proximity (centimeters) from external sensor: Q point 4
+// 0x0E temperature (degrees C) from external sensor: Q point 7
+
+/// executable/device channel responses
+/// Figure 1-27: SHTP executable commands and response
+// const EXECUTABLE_DEVICE_CMD_UNKNOWN: u8 =  0;
+const EXECUTABLE_DEVICE_CMD_RESET: u8 = 1;
+//const EXECUTABLE_DEVICE_CMD_ON: u8 =   2;
+//const EXECUTABLE_DEVICE_CMD_SLEEP =  3;
+
+/// Response to CMD_RESET
+const EXECUTABLE_DEVICE_RESP_RESET_COMPLETE: u8 = 1;
+
+/// Commands and subcommands
+const SH2_INIT_UNSOLICITED: u8 = 0x80;
+const SH2_CMD_INITIALIZE: u8 = 4;
+const SH2_INIT_SYSTEM: u8 = 1;
+const SH2_STARTUP_INIT_UNSOLICITED: u8 =
+    SH2_CMD_INITIALIZE | SH2_INIT_UNSOLICITED;


### PR DESCRIPTION
I made current drivers into an async version so they can be used with embassy for example. At the moment all the code is just duplicated in a separate async structs. Ideally it should be refactored that both blocking and async versions share common methods. Which one would you prefer?